### PR TITLE
Conversion tool between GOCART aerosol scheme and Thompson aerosol aware MP scheme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,9 @@ configure.wrf*
 *.backup
 *.f90
 chem/module_kpp*.F
-
+namelist.input.backup*
+compile.log
+compile.error
 
 # Out-of-source build locations
 _build*

--- a/phys/module_microphysics_driver.F
+++ b/phys/module_microphysics_driver.F
@@ -1213,6 +1213,23 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
                  end do Loop_j2
               end do Loop_k2
 
+              ! C.H. Lan 07.04.2025
+              deallocate (percen_seas1)
+              deallocate (percen_seas2)
+              deallocate (percen_seas3)
+              deallocate (percen_seas4)
+              deallocate (percen_oc_hphi)
+              deallocate (percen_oc_hpho)
+              deallocate (percen_so4)
+              deallocate (percen_bc_hphi)
+              deallocate (percen_bc_hpho)
+              deallocate (percen_dust1)
+              deallocate (percen_dust2)
+              deallocate (percen_dust3)
+              deallocate (percen_dust4)
+              deallocate (percen_dust5)
+              deallocate (qnhphoa_curr)
+
               if (pert_thom .and. multi_perturb == 1) then
                 call Remove_multi_perturb_mp_perturbations (perts_qvapor, perts_qcloud, perts_qice, &
                   perts_qsnow, perts_ni, pert_thom_qv, pert_thom_qc, pert_thom_qi, pert_thom_qs, &

--- a/phys/module_microphysics_driver.F
+++ b/phys/module_microphysics_driver.F
@@ -1066,23 +1066,22 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
                  qi_b4mp(its:ite,kts:kte,jts:jte) = qi_curr(its:ite,kts:kte,jts:jte)
                  qs_b4mp(its:ite,kts:kte,jts:jte) = qs_curr(its:ite,kts:kte,jts:jte)
 #endif
-            ! C.H. Lan 07.04.2025
-            allocate (percen_dust1(its:ite, kts:kte, jts:jte))
-            allocate (percen_dust2(its:ite, kts:kte, jts:jte))
-            allocate (percen_dust3(its:ite, kts:kte, jts:jte))
-            allocate (percen_dust4(its:ite, kts:kte, jts:jte))
-            allocate (percen_dust5(its:ite, kts:kte, jts:jte))
-            allocate (percen_seas1(its:ite, kts:kte, jts:jte))
-            allocate (percen_seas2(its:ite, kts:kte, jts:jte))
-            allocate (percen_seas3(its:ite, kts:kte, jts:jte))
-            allocate (percen_seas4(its:ite, kts:kte, jts:jte))
-            allocate (percen_oc_hphi(its:ite, kts:kte, jts:jte))
-            allocate (percen_oc_hpho(its:ite, kts:kte, jts:jte))
-            allocate (percen_so4(its:ite, kts:kte, jts:jte))
-            allocate (percen_bc_hphi(its:ite, kts:kte, jts:jte))
-            allocate (percen_bc_hpho(its:ite, kts:kte, jts:jte))
-            allocate (qnhphoa_curr(its:ite, kts:kte, jts:jte))
-
+               ! C.H. Lan 07.04.2025
+               allocate (percen_dust1(its:ite, kts:kte, jts:jte))
+               allocate (percen_dust2(its:ite, kts:kte, jts:jte))
+               allocate (percen_dust3(its:ite, kts:kte, jts:jte))
+               allocate (percen_dust4(its:ite, kts:kte, jts:jte))
+               allocate (percen_dust5(its:ite, kts:kte, jts:jte))
+               allocate (percen_seas1(its:ite, kts:kte, jts:jte))
+               allocate (percen_seas2(its:ite, kts:kte, jts:jte))
+               allocate (percen_seas3(its:ite, kts:kte, jts:jte))
+               allocate (percen_seas4(its:ite, kts:kte, jts:jte))
+               allocate (percen_oc_hphi(its:ite, kts:kte, jts:jte))
+               allocate (percen_oc_hpho(its:ite, kts:kte, jts:jte))
+               allocate (percen_so4(its:ite, kts:kte, jts:jte))
+               allocate (percen_bc_hphi(its:ite, kts:kte, jts:jte))
+               allocate (percen_bc_hpho(its:ite, kts:kte, jts:jte))
+               allocate (qnhphoa_curr(its:ite, kts:kte, jts:jte))
              CALL mp_gt_driver(                          &
                      QV=qv_curr,                         &
                      QC=qc_curr,                         &

--- a/phys/module_microphysics_driver.F
+++ b/phys/module_microphysics_driver.F
@@ -4,6 +4,17 @@
 MODULE module_microphysics_driver
   real, private, parameter :: QX_MIN = 1.E-12
   real, private, parameter :: NI_MIN = 1.E-6
+
+   ! C.H. Lan 07.03.2025
+   real, private, parameter, dimension(5) :: MASS2NUMBER_DUST = (/2.4547e+14, 3.2831e+13, &
+                                 6.5168e+12, 9.8862e+11, 1.7595e+11/)
+   real, private, parameter, dimension(5) :: MASS2NUMBER_SEASALT = (/3.0174e+17, 1.0851e+16, &
+                                 1.2070e+14, 9.3908e+12, 2.9217e+11 /)
+   real, private, parameter :: MASS2NUMBER_SO4 = 9.0143e+16
+   real, private, parameter  :: MASS2NUMBER_OC = 9.7576e+17
+   real, private, parameter  :: MASS2NUMBER_BC = 1.5002e+19
+   real, private, parameter :: MICROG2KG = 1.0e-9 
+
 CONTAINS
 
 SUBROUTINE microphysics_driver(                                          &

--- a/phys/module_microphysics_driver.F
+++ b/phys/module_microphysics_driver.F
@@ -1082,6 +1082,39 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
                allocate (percen_bc_hphi(its:ite, kts:kte, jts:jte))
                allocate (percen_bc_hpho(its:ite, kts:kte, jts:jte))
                allocate (qnhphoa_curr(its:ite, kts:kte, jts:jte))
+               ! C.H. Lan 07.04.2025
+               Loop_j: do j = jts, jte
+               Loop_k: do k = kts, kte
+                  Loop_i: do i = its, ite
+                     ! Water friendly
+                     percen_seas1(i, k, j) = chem(i, k, j, p_seas_1) * MICROG2KG * MASS2NUMBER_SEASALT(2)
+                     percen_seas2(i, k, j) = chem(i, k, j, p_seas_2) * MICROG2KG * MASS2NUMBER_SEASALT(3)
+                     percen_seas3(i, k, j) = chem(i, k, j, p_seas_3) * MICROG2KG * MASS2NUMBER_SEASALT(4)
+                     percen_seas4(i, k, j) = chem(i, k, j, p_seas_4) * MICROG2KG * MASS2NUMBER_SEASALT(5)
+                     percen_oc_hphi(i, k, j) = chem(i, k, j, p_oc2) * MICROG2KG * MASS2NUMBER_OC
+                     percen_so4(i, k, j) = chem(i, k, j, p_sulf) * MICROG2KG * MASS2NUMBER_SO4
+                     percen_bc_hphi(i, k, j) = chem(i, k, j, p_bc2) * MICROG2KG * MASS2NUMBER_BC
+                     qnwfa_curr(i, k, j) = percen_seas1(i, k, j) + percen_seas2(i, k, j) + percen_seas3(i, k, j) + &
+                                             percen_seas4(i, k, j) + percen_oc_hphi(i, k, j) + percen_so4(i, k, j) + &
+                                             percen_bc_hphi(i, k, j)
+                     ! ice friendly
+                     percen_dust1(i, k, j) = chem(i, k, j, p_dust_1) * MICROG2KG * MASS2NUMBER_DUST(1)
+                     percen_dust2(i, k, j) = chem(i, k, j, p_dust_2) * MICROG2KG * MASS2NUMBER_DUST(2)
+                     percen_dust3(i, k, j) = chem(i, k, j, p_dust_3) * MICROG2KG * MASS2NUMBER_DUST(3)
+                     percen_dust4(i, k, j) = chem(i, k, j, p_dust_4) * MICROG2KG * MASS2NUMBER_DUST(4)
+                     percen_dust5(i, k, j) = chem(i, k, j, p_dust_5) * MICROG2KG * MASS2NUMBER_DUST(5)
+                     qnifa_curr(i, k, j) = percen_dust1(i, k, j) + percen_dust2(i, k, j) + percen_dust3(i, k, j) + &
+                                             percen_dust4(i, k, j) + percen_dust5(i, k, j) 
+                     ! hydrophobic aerosols
+                     percen_oc_hpho(i, k, j) = chem(i, k, j, p_oc1) * MICROG2KG * MASS2NUMBER_OC
+                     percen_bc_hpho(i, k, j) = chem(i, k, j, p_bc1) * MICROG2KG * MASS2NUMBER_BC
+                     qnbca_curr(i, k, j) = percen_oc_hpho(i, k, j) + percen_bc_hpho(i, k, j)
+                  end do Loop_i
+               end do Loop_k
+            end do Loop_j
+            ! write(0,*)'sum nwfa', SUM(qnwfa_curr(its:ite,kts:kte,jts:jte))
+            ! write(0,*)'sum nhphoa', SUM(qnbca_curr(its:ite,kts:kte,jts:jte))
+            ! CALL wrf_debug ( 100 , 'microphysics_driver: calling thompson coupling GOCART' )
              CALL mp_gt_driver(                          &
                      QV=qv_curr,                         &
                      QC=qc_curr,                         &

--- a/phys/module_microphysics_driver.F
+++ b/phys/module_microphysics_driver.F
@@ -1126,7 +1126,7 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
                      ! change to percentage
                      percen_oc_hpho(i, k, j) = percen_oc_hpho(i, k, j) / qnbca_curr(i, k, j)
                      percen_bc_hpho(i, k, j) = percen_bc_hpho(i, k, j) / qnbca_curr(i, k, j)
-                     
+
                   end do Loop_i
                end do Loop_k
             end do Loop_j
@@ -1183,6 +1183,35 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
                  IDS=ids,IDE=ide, JDS=jds,JDE=jde, KDS=kds,KDE=kde, &
                  IMS=ims,IME=ime, JMS=jms,JME=jme, KMS=kms,KME=kme, &
                  ITS=its,ITE=ite, JTS=jts,JTE=jte, KTS=kts,KTE=kte)
+
+                 ! C.H. Lan 07.04.2025
+                 Loop_k2: do k = kts, kte
+                 Loop_j2: do j = jts, jte
+                    Loop_i2: do i = its, ite
+                       ! Water friendly
+                       if (qnwfa_curr(i, k, j) /= 11.1E6 .and. qnwfa_curr(i, k, j) /= 9999.E6) then
+                          chem(i, k, j, p_seas_1) =  qnwfa_curr(i, k, j) * percen_seas1(i, k, j) / MASS2NUMBER_SEASALT(2) / MICROG2KG
+                          chem(i, k, j, p_seas_2) =  qnwfa_curr(i, k, j) * percen_seas2(i, k, j) / MASS2NUMBER_SEASALT(3) / MICROG2KG
+                          chem(i, k, j, p_seas_3) =  qnwfa_curr(i, k, j) * percen_seas3(i, k, j) / MASS2NUMBER_SEASALT(4) / MICROG2KG
+                          chem(i, k, j, p_seas_4) =  qnwfa_curr(i, k, j) * percen_seas4(i, k, j) / MASS2NUMBER_SEASALT(5) / MICROG2KG
+                          chem(i, k, j, p_oc2) =  qnwfa_curr(i, k, j) * percen_oc_hphi(i, k, j) / MASS2NUMBER_OC / MICROG2KG
+                          chem(i, k, j, p_sulf) =  qnwfa_curr(i, k, j) * percen_so4(i, k, j) / MASS2NUMBER_SO4 / MICROG2KG
+                          chem(i, k, j, p_bc2) =  qnwfa_curr(i, k, j) * percen_bc_hphi(i, k, j) / MASS2NUMBER_BC / MICROG2KG   
+                       endif
+                       ! ice friendly
+                       if (qnifa_curr(i, k, j) /= 0.5E6*0.01 .and. qnifa_curr(i, k, j) /= 9999.E6) then
+                          chem(i, k, j, p_dust_1) =  qnifa_curr(i, k, j) * percen_dust1(i, k, j) / MASS2NUMBER_DUST(1) / MICROG2KG
+                          chem(i, k, j, p_dust_2) =  qnifa_curr(i, k, j) * percen_dust2(i, k, j) / MASS2NUMBER_DUST(2) / MICROG2KG
+                          chem(i, k, j, p_dust_3) =  qnifa_curr(i, k, j) * percen_dust3(i, k, j) / MASS2NUMBER_DUST(3) / MICROG2KG
+                          chem(i, k, j, p_dust_4) =  qnifa_curr(i, k, j) * percen_dust4(i, k, j) / MASS2NUMBER_DUST(4) / MICROG2KG
+                          chem(i, k, j, p_dust_5) =  qnifa_curr(i, k, j) * percen_dust5(i, k, j) / MASS2NUMBER_DUST(5) / MICROG2KG
+                       endif
+                     ! hydrophobic aerosols
+                       chem(i, k, j, p_oc1) =  qnbca_curr(i, k, j) * percen_oc_hpho(i, k, j) / MASS2NUMBER_OC / MICROG2KG
+                       chem(i, k, j, p_bc1) =  qnbca_curr(i, k, j) * percen_bc_hpho(i, k, j) / MASS2NUMBER_BC / MICROG2KG
+                    end do Loop_i2
+                 end do Loop_j2
+              end do Loop_k2
 
               if (pert_thom .and. multi_perturb == 1) then
                 call Remove_multi_perturb_mp_perturbations (perts_qvapor, perts_qcloud, perts_qice, &

--- a/phys/module_microphysics_driver.F
+++ b/phys/module_microphysics_driver.F
@@ -794,6 +794,11 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
    REAL :: constants_irrigation,tloc,irr_start,phase
    INTEGER, OPTIONAL, DIMENSION( ims:ime , jms:jme ), INTENT(INOUT) :: irr_rand_field
 
+   ! C.H. Lan 07.04.2025
+   real, dimension(:, :, :), allocatable :: percen_dust1, percen_dust2, percen_dust3, percen_dust4, percen_dust5, &
+       percen_seas1, percen_seas2, percen_seas3, percen_seas4, percen_oc_hphi, percen_oc_hpho, percen_so4, &
+       percen_bc_hphi, percen_bc_hpho, qnhphoa_curr  
+
 !---------------------------------------------------------------------
 !  check for microphysics type.  We need a clean way to
 !  specify these things!
@@ -1061,6 +1066,23 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
                  qi_b4mp(its:ite,kts:kte,jts:jte) = qi_curr(its:ite,kts:kte,jts:jte)
                  qs_b4mp(its:ite,kts:kte,jts:jte) = qs_curr(its:ite,kts:kte,jts:jte)
 #endif
+            ! C.H. Lan 07.04.2025
+            allocate (percen_dust1(its:ite, kts:kte, jts:jte))
+            allocate (percen_dust2(its:ite, kts:kte, jts:jte))
+            allocate (percen_dust3(its:ite, kts:kte, jts:jte))
+            allocate (percen_dust4(its:ite, kts:kte, jts:jte))
+            allocate (percen_dust5(its:ite, kts:kte, jts:jte))
+            allocate (percen_seas1(its:ite, kts:kte, jts:jte))
+            allocate (percen_seas2(its:ite, kts:kte, jts:jte))
+            allocate (percen_seas3(its:ite, kts:kte, jts:jte))
+            allocate (percen_seas4(its:ite, kts:kte, jts:jte))
+            allocate (percen_oc_hphi(its:ite, kts:kte, jts:jte))
+            allocate (percen_oc_hpho(its:ite, kts:kte, jts:jte))
+            allocate (percen_so4(its:ite, kts:kte, jts:jte))
+            allocate (percen_bc_hphi(its:ite, kts:kte, jts:jte))
+            allocate (percen_bc_hpho(its:ite, kts:kte, jts:jte))
+            allocate (qnhphoa_curr(its:ite, kts:kte, jts:jte))
+
              CALL mp_gt_driver(                          &
                      QV=qv_curr,                         &
                      QC=qc_curr,                         &

--- a/phys/module_microphysics_driver.F
+++ b/phys/module_microphysics_driver.F
@@ -1097,6 +1097,14 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
                      qnwfa_curr(i, k, j) = percen_seas1(i, k, j) + percen_seas2(i, k, j) + percen_seas3(i, k, j) + &
                                              percen_seas4(i, k, j) + percen_oc_hphi(i, k, j) + percen_so4(i, k, j) + &
                                              percen_bc_hphi(i, k, j)
+                     ! change to percentage
+                     percen_seas1(i, k, j) = percen_seas1(i, k, j) / qnwfa_curr(i, k, j)
+                     percen_seas2(i, k, j) = percen_seas2(i, k, j) / qnwfa_curr(i, k, j)
+                     percen_seas3(i, k, j) = percen_seas3(i, k, j) / qnwfa_curr(i, k, j)
+                     percen_seas4(i, k, j) = percen_seas4(i, k, j) / qnwfa_curr(i, k, j)
+                     percen_oc_hphi(i, k, j) = percen_oc_hphi(i, k, j) / qnwfa_curr(i, k, j)
+                     percen_so4(i, k, j) = percen_so4(i, k, j) / qnwfa_curr(i, k, j)
+                     percen_bc_hphi(i, k, j) = percen_bc_hphi(i, k, j) / qnwfa_curr(i, k, j)                        
                      ! ice friendly
                      percen_dust1(i, k, j) = chem(i, k, j, p_dust_1) * MICROG2KG * MASS2NUMBER_DUST(1)
                      percen_dust2(i, k, j) = chem(i, k, j, p_dust_2) * MICROG2KG * MASS2NUMBER_DUST(2)
@@ -1105,10 +1113,20 @@ REAL, DIMENSION( ims:ime, kms:kme, jms:jme ),                        &
                      percen_dust5(i, k, j) = chem(i, k, j, p_dust_5) * MICROG2KG * MASS2NUMBER_DUST(5)
                      qnifa_curr(i, k, j) = percen_dust1(i, k, j) + percen_dust2(i, k, j) + percen_dust3(i, k, j) + &
                                              percen_dust4(i, k, j) + percen_dust5(i, k, j) 
+                     ! change to percentage
+                     percen_dust1(i, k, j) = percen_dust1(i, k, j) / qnifa_curr(i, k, j)
+                     percen_dust2(i, k, j) = percen_dust2(i, k, j) / qnifa_curr(i, k, j)
+                     percen_dust3(i, k, j) = percen_dust3(i, k, j) / qnifa_curr(i, k, j)
+                     percen_dust4(i, k, j) = percen_dust4(i, k, j) / qnifa_curr(i, k, j)
+                     percen_dust5(i, k, j) = percen_dust5(i, k, j) / qnifa_curr(i, k, j)
                      ! hydrophobic aerosols
                      percen_oc_hpho(i, k, j) = chem(i, k, j, p_oc1) * MICROG2KG * MASS2NUMBER_OC
                      percen_bc_hpho(i, k, j) = chem(i, k, j, p_bc1) * MICROG2KG * MASS2NUMBER_BC
                      qnbca_curr(i, k, j) = percen_oc_hpho(i, k, j) + percen_bc_hpho(i, k, j)
+                     ! change to percentage
+                     percen_oc_hpho(i, k, j) = percen_oc_hpho(i, k, j) / qnbca_curr(i, k, j)
+                     percen_bc_hpho(i, k, j) = percen_bc_hpho(i, k, j) / qnbca_curr(i, k, j)
+                     
                   end do Loop_i
                end do Loop_k
             end do Loop_j

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -1239,6 +1239,7 @@
                nc1d(k) = nc(i,k,j)
                nwfa1d(k) = nwfa(i,k,j)
                nifa1d(k) = nifa(i,k,j)
+               nhphoa1d(k) = nbca(i,k,j) ! C.H. Lan 07.04.2025
                if (wif_input_opt .eq. 2) then
                   nbca1d(k) = nbca(i,k,j)
                else

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -1321,10 +1321,10 @@
          if (is_aerosol_aware) then
 !..Add anthropogenic emissions
 !-GT        nwfa1d(kts) = nwfa1
-            nwfa1d(kts) = nwfa1d(kts) + nwfa2d(i,j)*dt_in
-            nifa1d(kts) = nifa1d(kts) + nifa2d(i,j)*dt_in
+            nwfa1d(kts) = nwfa1d(kts) !+ nwfa2d(i,j)*dt_in
+            nifa1d(kts) = nifa1d(kts) !+ nifa2d(i,j)*dt_in
             if (wif_input_opt .eq. 2) then
-               nbca1d(kts) = nbca1d(kts) + nbca2d(i,j)*dt_in
+               nbca1d(kts) = nbca1d(kts) !+ nbca2d(i,j)*dt_in !C.H. Lan 07.04.2025
             else
                nbca1d(kts) = 0.0
             endif

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -1689,6 +1689,7 @@
          nwfaten(k) = 0.
          nifaten(k) = 0.
          nbcaten(k) = 0.
+         nhphoaten(k) = 0. ! C.H. Lan 07.04.2025
 
          prw_vcd(k) = 0.
 
@@ -1775,6 +1776,10 @@
          pnb_rcb(k) = 0.
          pnb_scb(k) = 0.
          pnb_gcb(k) = 0.
+
+         pnp_rcp(k) = 0.
+         pnp_scp(k) = 0.
+         pnp_gcp(k) = 0.
       enddo
 #if ( WRF_CHEM == 1 )
     if ( wetscav_on ) then

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -1253,6 +1253,7 @@
                nwfa1d(k) = 11.1E6/rho(k)
                nifa1d(k) = naIN1*0.01/rho(k)
                nbca1d(k) = 5.55E6/rho(k)
+               nhphoa1d(k) = 0.0 ! C.H. Lan 07.04.2025
             enddo
          endif
 
@@ -1286,7 +1287,8 @@
 
          call mp_thompson(aer_init_opt, wif_input_opt, &
                           qv1d, qc1d, qi1d, qr1d, qs1d, qg1d, qb1d, ni1d,     &
-                          nr1d, nc1d, ng1d, nwfa1d, nifa1d, nbca1d, t1d, p1d, w1d, dz1d,  &
+                          nr1d, nc1d, ng1d, nwfa1d, nifa1d, nbca1d, nhphoa1d,& ! C.H. Lan 07.04.2025
+                          t1d, p1d, w1d, dz1d,  &
                       pptrain, pptsnow, pptgraul, pptice, &
 #if ( WRF_CHEM == 1 )
                       wetscav_on, rainprod1d, evapprod1d, &
@@ -1515,6 +1517,7 @@
       subroutine mp_thompson (aer_init_opt, wif_input_opt, &
                           qv1d, qc1d, qi1d, qr1d, qs1d, qg1d, qb1d,       &
                           ni1d, nr1d, nc1d, ng1d, nwfa1d, nifa1d, nbca1d, &
+                          nhphoa1d,                                       & ! C.H. Lan 2025
                           t1d, p1d, w1d, dzq,                             &
                           pptrain, pptsnow, pptgraul, pptice, &
 #if ( WRF_CHEM == 1 )

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -1547,7 +1547,8 @@
 !..Local variables
       REAL, DIMENSION(kts:kte):: tten, qvten, qcten, qiten, qrten,            &
            qsten, qgten, qbten, niten, nrten, ncten, ngten, nwfaten, nifaten, &
-                                                              nbcaten
+                                                              nbcaten, &
+                                                              nhphoaten ! C.H. Lan 07.04.2025
 
       DOUBLE PRECISION, DIMENSION(kts:kte):: prw_vcd
 

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -2506,6 +2506,11 @@
               pnb_gcb(k) = MIN(DBLE(nbca(k)*odts), pnb_gcb(k))
             endif
           endif
+          ! hail wet scavenging for hydrophobic aerosols C.H. Lan 07.04.2025
+          Ef_ga = Eff_aero(xDg,0.0236E-6,visco(k),rho(k),temp(k),'g')
+          pnp_gcp(k) = rhof(k)*t1_qg_qc*Ef_ga*nhphoa(k)*N0_g(k)           &
+                        *ilamg(k)**cge(9,idx_bg(k))
+          pnp_gcp(k) = MIN(DBLE(nhphoa(k)*odts), pnp_gcp(k))
          endif
 
 !..Rain collecting snow.  Cannot assume Wisner (1972) approximation

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -1123,6 +1123,7 @@
       REAL, DIMENSION(kts:kte):: &
                           qv1d, qc1d, qi1d, qr1d, qs1d, qg1d, qb1d,     &
                           ni1d, nr1d, nc1d, ng1d, nwfa1d, nifa1d, nbca1d,&
+                          nhphoa1d,                                     & ! C.H. Lan 07.04.2025
                           t1d, p1d, w1d, dz1d, rho, dBZ
       REAL, DIMENSION(kts:kte):: re_qc1d, re_qi1d, re_qs1d
 #if ( WRF_CHEM == 1 )

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -1533,7 +1533,8 @@
       INTEGER, INTENT(IN):: kts, kte, ii, jj
       REAL, DIMENSION(kts:kte), INTENT(INOUT):: &
                           qv1d, qc1d, qi1d, qr1d, qs1d, qg1d, qb1d,     &
-                          ni1d, nr1d, nc1d, ng1d, nwfa1d, nifa1d, nbca1d, t1d
+                          ni1d, nr1d, nc1d, ng1d, nwfa1d, nifa1d, nbca1d, t1d, &
+                          nhphoa1d ! C.H. Lan 07.04.2025
       REAL, DIMENSION(kts:kte), INTENT(IN):: p1d, w1d, dzq
       REAL, INTENT(INOUT):: pptrain, pptsnow, pptgraul, pptice
       REAL, INTENT(IN):: dt

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -1585,7 +1585,8 @@
 
       REAL, DIMENSION(kts:kte):: temp, twet, pres, qv
       REAL, DIMENSION(kts:kte):: rc, ri, rr, rs, rg, rb
-      REAL, DIMENSION(kts:kte):: ni, nr, nc, ns, ng, nwfa, nifa, nbca
+      REAL, DIMENSION(kts:kte):: ni, nr, nc, ns, ng, nwfa, nifa, nbca, &
+           nhphoa ! C.H. Lan 07.04.2025
       REAL, DIMENSION(kts:kte):: rho, rhof, rhof2
       REAL, DIMENSION(kts:kte):: qvs, qvsi, delQvs
       REAL, DIMENSION(kts:kte):: satw, sati, ssatw, ssati

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -2246,6 +2246,13 @@
               pnb_rcb(k) = MIN(DBLE(nbca(k)*odts), pnb_rcb(k))
             endif
           endif
+
+          ! add wet scavenging of hydrophobic aerosols  C.H Lan 07.04.2025
+          Ef_ra = Eff_aero(mvd_r(k),0.0236E-6,visco(k),rho(k),temp(k),'r')
+          pnp_rcp(k) = rhof(k)*t1_qr_qc*Ef_ra*nhphoa(k)*N0_r(k)           &
+                         *((lamr+fv_r)**(-cre(9)))
+          pnp_rcp(k) = MIN(DBLE(nhphoa(k)*odts), pnp_rcp(k))
+
          endif
 
       enddo

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -1816,8 +1816,9 @@
          rho(k) = 0.622*pres(k)/(R*temp(k)*(qv(k)+0.622))
          if (is_aerosol_aware) then
             if (aer_init_opt .lt. 2) then  ! Constant or climatology (e.g., GOCART)
-               nwfa(k) = MAX(11.1E6, MIN(9999.E6, nwfa1d(k)*rho(k)))
-               nifa(k) = MAX(naIN1*0.01, MIN(9999.E6, nifa1d(k)*rho(k)))
+               nwfa(k) = MAX(0.0, nwfa1d(k)*rho(k))
+               nifa(k) = MAX(0.0, nifa1d(k)*rho(k)) ! C.H. Lan 07.04.2025
+               nhphoa(k) = MAX(0.0, nhphoa1d(k)*rho(k)) ! C.H. Lan 07.04.2025
                if (wif_input_opt .eq. 2) then  ! Considering BC aerosol
                   nbca(k) = MAX(5.55E6, MIN(9999.E6, nbca1d(k)*rho(k)))
                else
@@ -1826,6 +1827,7 @@
             else   ! First guess (e.g., GEOS-5)
                nwfa(k) = MAX(0.0, nwfa1d(k)*rho(k))
                nifa(k) = MAX(0.0, nifa1d(k)*rho(k))
+               nhphoa(k) = MAX(0.0, nhphoa1d(k)*rho(k)) ! C.H. Lan 07.04.2025
                if (wif_input_opt .eq. 2) then  ! Considering BC aerosol
                   nbca(k) = MAX(0.0, nbca1d(k)*rho(k))
                else

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -4012,19 +4012,23 @@
          nc1d(k) = MAX(2./rho(k), MIN(nc1d(k) + ncten(k)*DT, Nt_c_max))
          if (is_aerosol_aware) then
             if (aer_init_opt .lt. 2) then
-               nwfa1d(k) = MAX(11.1E6, MIN(9999.E6,                           &
-                             (nwfa1d(k)+nwfaten(k)*DT)))
-               nifa1d(k) = MAX(naIN1*0.01, MIN(9999.E6,                       &
-                             (nifa1d(k)+nifaten(k)*DT)))
+               ! nwfa1d(k) = MAX(11.1E6, MIN(9999.E6,                           &
+               !               (nwfa1d(k)+nwfaten(k)*DT)))
+               ! nifa1d(k) = MAX(naIN1*0.01, MIN(9999.E6,                       &
+               !               (nifa1d(k)+nifaten(k)*DT)))
+               nwfa1d(k) = MAX(0.0, (nwfa1d(k)+nwfaten(k)*DT))
+               nifa1d(k) = MAX(0.0, (nifa1d(k)+nifaten(k)*DT))
                if (wif_input_opt .eq. 2) then
                   nbca1d(k) = MAX(5.55E6, MIN(9999.E6,                        &
                                 (nbca1d(k)+nbcaten(k)*DT)))
                else
                   nbca1d(k) = 0.0
                endif
+               nhphoa1d(k)  = MAX(0.0, (nhphoa1d(k)+nhphoaten(k)*DT)) ! C.H. Lan 07.04.2025
             else
                nwfa1d(k) = MAX(0.0, (nwfa1d(k)+nwfaten(k)*DT))
                nifa1d(k) = MAX(0.0, (nifa1d(k)+nifaten(k)*DT))
+               nhphoa1d(k)  = MAX(0.0, (nhphoa1d(k)+nhphoaten(k)*DT)) ! C.H. Lan 07.04.2025
                if (wif_input_opt .eq. 2) then
                   nbca1d(k) = MAX(0.0, (nbca1d(k)+nbcaten(k)*DT))
                else
@@ -4038,6 +4042,7 @@
                           (nifa1d(k)+nifaten(k)*DT)))
             nbca1d(k) = MAX(5.55E6, MIN(9999.E6,                           &
                           (nbca1d(k)+nbcaten(k)*DT)))
+            nhphoa1d(k)  = MAX(0.0, (nhphoa1d(k)+nhphoaten(k)*DT)) ! C.H. Lan 07.04.2025          
          endif
 
          if (qc1d(k) .le. R1) then

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -1556,7 +1556,7 @@
            pnc_scw, pnc_gcw
 
       DOUBLE PRECISION, DIMENSION(kts:kte):: pna_rca, pna_sca, pna_gca, &
-           pnd_rcd, pnd_scd, pnd_gcd, pnb_rcb, pnb_scb, pnb_gcb
+            pnd_rcd, pnd_scd, pnd_gcd, pnb_rcb, pnb_scb, pnb_gcb, pnp_rcp, pnp_scp, pnp_gcp ! C.H. Lan 07.04.2025
 
       DOUBLE PRECISION, DIMENSION(kts:kte):: prr_wau, prr_rcw, prr_rcs, &
            prr_rcg, prr_sml, prr_gml, &

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -1838,6 +1838,7 @@
             nwfa(k) = MAX(11.1E6, MIN(9999.E6, nwfa1d(k)*rho(k)))
             nifa(k) = MAX(naIN1*0.01, MIN(9999.E6, nifa1d(k)*rho(k)))
             nbca(k) = MAX(5.55E6, MIN(9999.E6, nbca1d(k)*rho(k)))
+            nhphoa(k) = MAX(0.0, nhphoa1d(k)*rho(k)) ! C.H. Lan 07.04.2025
          endif
 
          if (qc1d(k) .gt. R1) then

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -1341,6 +1341,7 @@
                else
                   nbca(i,k,j) = 0.0
                endif
+               nbca(i,k,j) = nhphoa1d(k) ! C.H. Lan 07.04.2025
             enddo
          endif
          if (is_hail_aware) then

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -3243,7 +3243,8 @@
          ocp(k) = 1./(Cp*(1.+0.887*qv(k)))
          lvt2(k)=lvap(k)*lvap(k)*ocp(k)*oRv*otemp*otemp
 
-         nwfa(k) = MAX(11.1E6, (nwfa1d(k) + nwfaten(k)*DT)*rho(k))
+         !nwfa(k) = MAX(11.1E6, (nwfa1d(k) + nwfaten(k)*DT)*rho(k))
+         nwfa(k) = MAX(0.0, (nwfa1d(k) + nwfaten(k)*DT)*rho(k)) ! C.H. Lan 07.04.2025
       enddo
 
       do k = kts, kte

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -2480,6 +2480,10 @@
               pnb_scb(k) = MIN(DBLE(nbca(k)*odts), pnb_scb(k))
             endif
           endif
+          ! snow wet scavenging for hydrophobic aerosols C.H. Lan 07.04.2025
+          Ef_sa = Eff_aero(xDs,0.0236E-6,visco(k),rho(k),temp(k),'s')
+          pnp_scp(k) = rhof(k)*t1_qs_qc*Ef_sa*nhphoa(k)*smoe(k)
+          pnp_scp(k) = MIN(DBLE(nhphoa(k)*odts), pnp_scp(k))
          endif
          if (rg(k) .gt. r_g(1)) then
           xDg = (bm_g + mu_g + 1.) * ilamg(k)

--- a/phys/module_mp_thompson.F
+++ b/phys/module_mp_thompson.F
@@ -2998,6 +2998,8 @@
                        + pna_gca(k) + pni_iha(k)) * orho
             nifaten(k) = nifaten(k) - (pnd_rcd(k) + pnd_scd(k)          &
                        + pnd_gcd(k)) * orho
+            nhphoaten(k) = nhphoaten(k) - (pnp_rcp(k) + pnp_scp(k)      & ! C.H. Lan 07.04.2025
+                        + pnp_gcp(k)) * orho
             if (wif_input_opt .eq. 2) then
                nbcaten(k) = nbcaten(k) - (pnb_rcb(k) + pnb_scb(k)       &
                           + pnb_gcb(k)) * orho


### PR DESCRIPTION
Convert and regroup GOCART mass concentration (mg/kg) to THOMPSON-AERO CCN number concentration (#/kg).
The conversion tool is referenced by Pedro's REPO (the link).
we design the three groups for CCN categories.
1. water friendly aerosol - including the sulfate, sea salt for 4 bins, and hydrophilic OC and BC.
2. ice friendly aerosol - including the dust for 5 bins.
3. hydrophobic aerosol - including the hydrophobic OC and BC. only treat the wet scavenging in MP scheme.